### PR TITLE
Fix possible buffer overflow in _Cellular_RecvFuncGetPdpContextSettings

### DIFF
--- a/source/cellular_r4.h
+++ b/source/cellular_r4.h
@@ -124,10 +124,10 @@ typedef enum MNOProfileType
  */
 typedef struct CellularPdnContextInfo
 {
-    bool contextsPresent[ MAX_PDP_CONTEXTS ];                             /**< Context present in +CGDCONT response or not. */
-    char ipType[ MAX_PDP_CONTEXTS ][ CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE ]; /**< PDN Context type. */
-    char apnName[ MAX_PDP_CONTEXTS ][ CELLULAR_APN_MAX_SIZE ];            /**< APN name. */
-    char ipAddress[ MAX_PDP_CONTEXTS ][ CELLULAR_IP_ADDRESS_MAX_SIZE ];   /**< IP address. */
+    bool contextsPresent[ MAX_PDP_CONTEXTS ];                                  /**< Context present in +CGDCONT response or not. */
+    char ipType[ MAX_PDP_CONTEXTS ][ CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE + 1U ]; /**< PDN Context type. */
+    char apnName[ MAX_PDP_CONTEXTS ][ CELLULAR_APN_MAX_SIZE + 1U ];            /**< APN name. */
+    char ipAddress[ MAX_PDP_CONTEXTS ][ CELLULAR_IP_ADDRESS_MAX_SIZE + 1U ];   /**< IP address. */
 } CellularPdnContextInfo_t;
 
 /**

--- a/source/cellular_r4_api.c
+++ b/source/cellular_r4_api.c
@@ -2495,22 +2495,43 @@ static CellularPktStatus_t _Cellular_RecvFuncGetPdpContextSettings( CellularCont
                             case ( CELLULAR_PDN_STATUS_POS_CONTEXT_TYPE ):
                                 LogDebug( ( "_Cellular_RecvFuncGetPdpContextSettings: Context Type pToken: %s", pToken ) );
 
-                                ( void ) memcpy( ( void * ) pPDPContextsInfo->ipType[ contextId - 1 ],
-                                                 ( void * ) pToken, CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE + 1U );
+                                ( void ) strncpy( ( void * ) pPDPContextsInfo->ipType[ contextId - 1 ],
+                                                  ( void * ) pToken, CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE + 1U );
+
+                                if( pPDPContextsInfo->ipType[ contextId - 1 ][ CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE ] != '\0' )
+                                {
+                                    LogWarn( ( "_Cellular_RecvFuncGetPdpContextSettings: Context Type pToken: %s longer than CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE.", pToken ) );
+                                    pPDPContextsInfo->ipType[ contextId - 1 ][ CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE ] = '\0';
+                                }
+
                                 break;
 
                             case ( CELLULAR_PDN_STATUS_POS_APN_NAME ):
                                 LogDebug( ( "_Cellular_RecvFuncGetPdpContextSettings: Context APN name pToken: %s", pToken ) );
 
-                                ( void ) memcpy( ( void * ) pPDPContextsInfo->apnName[ contextId - 1 ],
-                                                 ( void * ) pToken, CELLULAR_APN_MAX_SIZE + 1U );
+                                ( void ) strncpy( ( void * ) pPDPContextsInfo->apnName[ contextId - 1 ],
+                                                  ( void * ) pToken, CELLULAR_APN_MAX_SIZE + 1U );
+
+                                if( pPDPContextsInfo->apnName[ contextId - 1 ][ CELLULAR_APN_MAX_SIZE ] != '\0' )
+                                {
+                                    LogWarn( ( "_Cellular_RecvFuncGetPdpContextSettings: Context APN name pToken: %s longer than CELLULAR_APN_MAX_SIZE.", pToken ) );
+                                    pPDPContextsInfo->apnName[ contextId - 1 ][ CELLULAR_APN_MAX_SIZE ] = '\0';
+                                }
+
                                 break;
 
                             case ( CELLULAR_PDN_STATUS_POS_IP_ADDRESS ):
                                 LogDebug( ( "_Cellular_RecvFuncGetPdpContextSettings: Context IP address pToken: %s", pToken ) );
 
-                                ( void ) memcpy( ( void * ) pPDPContextsInfo->ipAddress[ contextId - 1 ],
-                                                 ( void * ) pToken, CELLULAR_IP_ADDRESS_MAX_SIZE + 1U );
+                                ( void ) strncpy( ( void * ) pPDPContextsInfo->ipAddress[ contextId - 1 ],
+                                                  ( void * ) pToken, CELLULAR_IP_ADDRESS_MAX_SIZE + 1U );
+
+                                if( pPDPContextsInfo->ipAddress[ contextId - 1 ][ CELLULAR_IP_ADDRESS_MAX_SIZE ] != '\0' )
+                                {
+                                    LogWarn( ( "_Cellular_RecvFuncGetPdpContextSettings: Context IP address pToken: %s longer than CELLULAR_IP_ADDRESS_MAX_SIZE.", pToken ) );
+                                    pPDPContextsInfo->ipAddress[ contextId - 1 ][ CELLULAR_IP_ADDRESS_MAX_SIZE ] = '\0';
+                                }
+
                                 break;
 
                             default:


### PR DESCRIPTION
Fix possible buffer overflow in _Cellular_RecvFuncGetPdpContextSettings

Description
-----------
The following macros defines the length of string but the terminated char is not included.
* CELULAR_PDN_CONTEXT_TYPE_MAX_SIZE
* CELLULAR_APN_MAX_SIZE
* CELLULAR_IP_ADDRESS_MAX_SIZE

In this PR:
* Increase the string size by 1 to include the terminated char to prevent possible buffer overflow.
* Use strncpy instead of memcpy for NULL terminated character.

Test Steps
-----------
Calling Cellular_SetPdnConfig AP and modify the CELLULAR_IP_ADDRESS_MAX_SIZE to a value smaller than the IP address returned by modem.

Before this PR there will be error due to no terminated char and buffer overflow.
After this PR, there will be warning message.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.

Related Issue
-----------
Address the issue #5 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
